### PR TITLE
Updated module_datastore and added dbsetup.sh

### DIFF
--- a/data_store/module_datastore.py
+++ b/data_store/module_datastore.py
@@ -1,13 +1,24 @@
 import zmq
 import psycopg2
-#for testing
-from datetime import datetime
+import time
 
 #####OPTIONS############
 module_in = "ipc://module_i2c"
 db_name = "rLoop"
-db_user = "peter"
+db_user = "rloop" #rloop - DY
 ########################
+
+#####
+#Sensor Identity 
+SensorName='TestSens'
+
+#CONCEPT: Store attribute listing and handle all the info on python prior to DB insertion
+#Attribute = ["Test1", "Test2", "Test3"] #AttributeNames
+
+#####
+#GLOBAL SWITCH
+ZMQActive = 0
+POSTGRESACTIVE = 0
 
 #SOCKET
 
@@ -15,48 +26,66 @@ context = zmq.Context()
 #this is a subscriber socket
 receiver = context.socket(zmq.SUB)
 
-###MISSING: exception handling!
-receiver.connect(module_in)
-# subscribe!
+while(1):
+    try:
+       #Nothing can really be done when receiver is gone
+       #Can only tell base station that receiver connection has failed
+       receiver.connect(module_in)
+       ZMQActive = 1
+       break
+
+    except:
+       print "Receiver connection failed"
+
+       #Perhaps forward this information to base station via a different protocol?
+       #GSM, ICMP, BPSK-DSSS,...
+       time.sleep(1) 
+       #Wait 1 second for reconnect
+
+# Please give a thumbs up, like and subscribe to my ZMQ socket!
 receiver.setsockopt(zmq.SUBSCRIBE,"")
 
 
 #DATABASE
+#Add pytime with the sql NOW() in case DB dies for caching
 
-###MISSING: exception handling!
-db_con =  psycopg2.connect("dbname=%s user=%s" % (db_name, db_user))
-db_cursor = db_con.cursor()
+QueryCache = []
 
+while 1:
+    try:
+        db_con =  psycopg2.connect("dbname=%s user=%s" % (db_name, db_user))
+        db_cursor = db_con.cursor()
+        POSTGRESACTIVE = 1
+    except:
+        print "Postgres is down, connection failed"
 
-#MAIN LOOP
-'''
-while True:
-	#TEST: creating random data
-	sid = 10
-	aid = 2
-	timestamp = datetime.utcnow()
-	value = float(1234)
-	#get Data from i2c module
-###MISSING: data format we are getting...
+        if(ZMQActive):
+
+            #Implement a loop here to continuous capture data from ZMQ but save it in a cache, either Local Redis or Postgres
+            CacheTS = time.time()
+            value = float(1234)
+            #Need to get data from i2c via ZMQ
+            QueryCache.append("""INSERT INTO Data VALUES (select sid from Sensors where SensorName = {SensName}, select aid from Attributes where AttrName = {AttrName}, {TimeStamp},{DataVal} );""",(SensName = SensorName, AttrName = Attribute, TimeStamp = CacheTS, DataVal = value))
+
+#Submit all the uninserted queries during DB recovery
+for i in QueryCache:
+   db_cursor.execute(i)
+
+while 1:
 	try:
-		buf = receiver.recv()
-		print buf
+            buf = receiver.recv()
+            print buf
 	except KeyboardInterrupt:
-		break
+            break
+
 	#store it in the database somehow
 ###MISSING: which table do we write to? Is this decided here or do we write to the same table every time? In this case put a variable in the "OPTIONS" section
-	# db_cursor.execute("""INSERT INTO Data VALUES (%s, %s, %s, %s);""",(sid, aid, timestamp, value))
-	#commit the changes
-	# db_con.commit()
-'''
-#testing
-sid = 1
-aid = 1
-timestamp = datetime.utcnow()
-value = float(0.05)
-db_cursor.execute("""INSERT INTO Data VALUES (%s, %s, %s, %s);""",(sid, aid, timestamp, value))
-db_con.commit()
-#this should be executed when the program is stopped
+
+        Attribute='TestA'
+        value = float(1234)
+        db_cursor.execute("""INSERT INTO Data VALUES (select sid from Sensors where SensorName = {SensName}, select aid from Attributes where AttrName = {AttrName}, NOW(),{DataVal} );""",(SensName = SensorName, AttrName = Attribute, DataVal = value))
+	db_con.commit()
+
 #terminate db connection
 db_cursor.close()
 db_con.close()

--- a/init/dbsetup.sh
+++ b/init/dbsetup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "SETTING UP AND INSTALLING ENVIRONMENT\n"
+
+sudo apt-get install postgresql
+sudo service enable postgresql
+sudo service start postgresql
+git clone https://github.com/rLoopTeam/eng-software-pi.git
+sudo -u postgres createuser -s -d -r rloop
+createdb rloopSensor
+psql -u rloop -d rloopSensor -f ./eng-software-pi/init/createdb.sql
+
+echo "DB INITIALIZED\n"


### PR DESCRIPTION
  IMPLEMENTED
- module_datastore is updated to be more fault tolerant in the event of
  lost ZMQ connections or Database down time
- ZMQ connections will now try to reconnect every second until receiver
  and attached with a sender which will be groundstation
- module_datastore will cache queries until the DB spins back up and
  will insert all the queries into the DB once its up
- Added dbsetup.sh for Postgres construction, would be great if someone
  will finish the implementation
  
  TO DO
- Might want to try a new concept with an Attribute List such that upon
  receiving the sensors stream, a single loop can faciliate all the
  insertions required for the sensor.
- Might want to implement heartbeat in someway to notify the
  groundstation to reestablish ZMQ connection
